### PR TITLE
fix: move clipboardy to prod dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
     "@typescript-eslint/eslint-plugin": "^8.26.1",
     "@typescript-eslint/parser": "^8.26.1",
     "@vitest/coverage-v8": "^3.0.8",
-    "clipboardy": "^4.0.0",
     "eslint": "^9.22.0",
     "eslint-plugin-unused-imports": "^4.1.4",
     "execa": "^9.5.2",
@@ -154,6 +153,7 @@
     "vitest": "^3.0.8"
   },
   "dependencies": {
+    "clipboardy": "^4.0.0",
     "@clack/prompts": "^0.10.0",
     "@octokit/rest": "^21.1.1",
     "@types/micromatch": "^4.0.9",


### PR DESCRIPTION
To fix the problem after installation

```
$ ffg
node:internal/modules/esm/resolve:838
  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
        ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'clipboardy' imported from /Users/bahmutov/.nvm/versions/node/v22.11.0/lib/node_modules/@johnlindquist/file-forge/dist/index.js
    at packageResolve (node:internal/modules/esm/resolve:838:9)
    at moduleResolve (node:internal/modules/esm/resolve:907:18)
    at defaultResolve (node:internal/modules/esm/resolve:1037:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:650:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:599:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:582:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:241:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:132:49) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v22.11.0

```