### PR TITLE
feat: include original command in XML output

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,37 @@
+name: PR Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - run: pnpm install
+      - run: pnpm build
+      - run: pnpm test
+      - name: Verify CLI
+        run: |
+          pnpm link --global
+          ffg --help || exit 1 

--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ dist
 
 # test/.gitignore
 !fixtures/**/*
+fixtures/**/binary*
 plans
 *.diff
 diffs

--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ ffg --graph src/index.js
   ffg src --debug
   ffg src --verbose
   ```
+- **Command Traceability:**
+  The original command used to generate the output is now included in the XML output for better traceability.
+  ```xml
+  <project>
+    <source>/path/to/source</source>
+    <timestamp>20240324-123456</timestamp>
+    <command>ffg src --verbose</command>
+  </project>
+  ```
 - **Using AI Prompt Templates:**
   ```bash
   # List all available templates

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,9 @@ export async function handleOutput(
 ) {
   const timestamp = format(new Date(), "yyyyMMdd-HHmmss");
 
+  // Capture the original command
+  const originalCommand = process.argv.slice(2).join(' ');
+
   // If digest is null, create an empty digest
   const safeDigest = digest || {
     [PROP_SUMMARY]: "No files found or directory is empty",
@@ -89,12 +92,13 @@ export async function handleOutput(
     ...argv,
     verbose: true, // Always include file contents in file output
     pipe: false, // Never pipe for file output to ensure XML wrapping works
+    command: originalCommand, // Include the original command
   });
 
   // For console output, respect the verbose flag and preserve the name property
   const consoleOutput = buildOutput(safeDigest, source, timestamp, {
     ...argv,
-    // Preserve name property for header
+    command: originalCommand, // Include the original command
   });
 
   // Only count tokens if not disabled

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,8 +77,8 @@ export async function handleOutput(
 ) {
   const timestamp = format(new Date(), "yyyyMMdd-HHmmss");
 
-  // Capture the original command
-  const originalCommand = process.argv.slice(2).join(' ');
+  // Capture the original command with the executable name
+  const originalCommand = `ffg ${process.argv.slice(2).join(' ')}`;
 
   // If digest is null, create an empty digest
   const safeDigest = digest || {

--- a/src/outputFormatter.ts
+++ b/src/outputFormatter.ts
@@ -44,13 +44,14 @@ export function buildOutput(
     const contentParts = [
       `**Source**: \`${source}\``,
       `**Timestamp**: ${timestamp}`,
+      options.command ? `**Command**: \`${options.command}\`` : null,
       "## Summary",
       digest[PROP_SUMMARY] || "",
       "## Directory Structure",
       "```",
       digest[PROP_TREE] || "",
       "```",
-    ];
+    ].filter(Boolean);
 
     // Add file contents section if verbose is enabled, saving to file, or clipboard is enabled
     if (options.verbose || options.debug || !options.pipe || options.clipboard) {

--- a/src/outputFormatter.ts
+++ b/src/outputFormatter.ts
@@ -12,6 +12,7 @@ interface OutputOptions {
   clipboard?: boolean | undefined;
   xml?: boolean | undefined;
   markdown?: boolean | undefined;
+  command?: string | undefined;
   [key: string]: unknown;
 }
 
@@ -116,5 +117,6 @@ export function buildOutput(
     template: options.template,
     bulk: options.bulk,
     verbose: options.verbose || options.debug || !options.pipe || options.clipboard,
+    command: options.command,
   });
 }

--- a/src/xmlFormatter.ts
+++ b/src/xmlFormatter.ts
@@ -9,6 +9,7 @@ interface XMLOutputOptions {
     template?: string | undefined;
     bulk?: boolean | undefined;
     verbose?: boolean | undefined;
+    command?: string | undefined;
 }
 
 /**
@@ -81,6 +82,9 @@ export function buildXMLOutput(
     xml += `  <project>\n`;
     xml += `    <source>${escapeXML(source)}</source>\n`;
     xml += `    <timestamp>${escapeXML(timestamp)}</timestamp>\n`;
+    if (options.command) {
+        xml += `    <command>${escapeXML(options.command)}</command>\n`;
+    }
 
     // Add Git information if available
     const gitInfo = getGitInfo(source);

--- a/test/digest-content.test.ts
+++ b/test/digest-content.test.ts
@@ -43,6 +43,7 @@ describe("Digest File Content", () => {
     expect(stdout).toContain("# File Forge Analysis");
     expect(stdout).toContain("**Source**:");
     expect(stdout).toContain("**Timestamp**:");
+    expect(stdout).toContain("**Command**: `ffg --path test/fixtures/sample-project --markdown --pipe --verbose`");
     expect(stdout).toContain("## Directory Structure");
     expect(stdout).toContain("## Files Content");
 

--- a/test/xmlFormatter.test.ts
+++ b/test/xmlFormatter.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { buildXMLOutput } from "../src/xmlFormatter";
+import { PROP_SUMMARY, PROP_TREE, PROP_CONTENT } from "../src/constants";
+
+describe("XML Formatter", () => {
+    it("should include command in output when provided", () => {
+        const digest = {
+            [PROP_SUMMARY]: "Test summary",
+            [PROP_TREE]: "Test tree",
+            [PROP_CONTENT]: "Test content"
+        };
+        const source = "/test/path";
+        const timestamp = "20240101-000000";
+        const command = "ffg test --verbose";
+
+        const output = buildXMLOutput(digest, source, timestamp, {
+            command,
+            verbose: true
+        });
+
+        expect(output).toContain(`<command>${command}</command>`);
+    });
+
+    it("should not include command tag when command is not provided", () => {
+        const digest = {
+            [PROP_SUMMARY]: "Test summary",
+            [PROP_TREE]: "Test tree",
+            [PROP_CONTENT]: "Test content"
+        };
+        const source = "/test/path";
+        const timestamp = "20240101-000000";
+
+        const output = buildXMLOutput(digest, source, timestamp, {
+            verbose: true
+        });
+
+        expect(output).not.toContain("<command>");
+    });
+}); 


### PR DESCRIPTION
## Summary
Added functionality to include the original CLI command in the XML output for better traceability.

## Changes Made
- Modified output generation to include executed command
- Added tests to verify functionality
- Updated documentation

## Justification
This helps users understand exactly how the output was generated, which is particularly useful when sharing or reviewing analysis results.

## Testing
- Added new test cases
- Verified all existing tests pass
- Manually verified output contains command

## Dependencies
None - no new dependencies added
