### PR TITLE
Add Git hooks to prevent direct commits and pushes to main branch

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,14 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# Prevent committing to main branch
+branch="$(git symbolic-ref --short HEAD)"
+if [ "$branch" = "main" ]; then
+  echo "❌ You can't commit directly to the main branch!"
+  echo "Please create a feature branch and use pull requests instead."
+  exit 1
+fi
+
 # Install deps, lint, type check, test
 pnpm install && \
 pnpm eslint . --fix --max-warnings 0 && \

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Prevent direct pushes to main branch
+protected_branch="main"
+current_branch=$(git symbolic-ref --short HEAD)
+
+if [ "$current_branch" = "$protected_branch" ]; then
+  echo "❌ You can't push directly to the $protected_branch branch!"
+  echo "Please create a feature branch and use pull requests instead."
+  exit 1
+fi
+
+while read local_ref local_sha remote_ref remote_sha
+do
+  if [ "$remote_ref" = "refs/heads/$protected_branch" ]; then
+    echo "❌ You can't push directly to the $protected_branch branch!"
+    echo "Please create a feature branch and use pull requests instead."
+    exit 1
+  fi
+done 


### PR DESCRIPTION
This PR adds Git hooks that prevent direct commits and pushes to the main branch, encouraging developers to use feature branches and pull requests instead for all changes.