### PR TITLE
fix: update husky hooks to fix semantic-release workflow

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,16 +1,18 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+#!/bin/sh
 
-# Prevent committing to main branch
-branch="$(git symbolic-ref --short HEAD)"
-if [ "$branch" = "main" ]; then
-  echo "❌ You can't commit directly to the main branch!"
-  echo "Please create a feature branch and use pull requests instead."
-  exit 1
+# Skip checks in CI environments
+if [ -z "$CI" ]; then
+  # Prevent committing to main branch
+  branch="$(git symbolic-ref --short HEAD)"
+  if [ "$branch" = "main" ]; then
+    echo "❌ You can't commit directly to the main branch!"
+    echo "Please create a feature branch and use pull requests instead."
+    exit 1
+  fi
+
+  # Install deps, lint, type check, test
+  pnpm install && \
+  pnpm eslint . --fix --max-warnings 0 && \
+  pnpm tsc --noEmit --strict && \
+  pnpm test
 fi
-
-# Install deps, lint, type check, test
-pnpm install && \
-pnpm eslint . --fix --max-warnings 0 && \
-pnpm tsc --noEmit --strict && \
-pnpm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,21 +1,22 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+#!/bin/sh
 
-# Prevent direct pushes to main branch
-protected_branch="main"
-current_branch=$(git symbolic-ref --short HEAD)
+# Prevent direct pushes to main branch (skips check in CI environments)
+if [ -z "$CI" ]; then
+  protected_branch="main"
+  current_branch=$(git symbolic-ref --short HEAD)
 
-if [ "$current_branch" = "$protected_branch" ]; then
-  echo "❌ You can't push directly to the $protected_branch branch!"
-  echo "Please create a feature branch and use pull requests instead."
-  exit 1
-fi
-
-while read local_ref local_sha remote_ref remote_sha
-do
-  if [ "$remote_ref" = "refs/heads/$protected_branch" ]; then
+  if [ "$current_branch" = "$protected_branch" ]; then
     echo "❌ You can't push directly to the $protected_branch branch!"
     echo "Please create a feature branch and use pull requests instead."
     exit 1
   fi
-done 
+
+  while read local_ref local_sha remote_ref remote_sha
+  do
+    if [ "$remote_ref" = "refs/heads/$protected_branch" ]; then
+      echo "❌ You can't push directly to the $protected_branch branch!"
+      echo "Please create a feature branch and use pull requests instead."
+      exit 1
+    fi
+  done 
+fi 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:fix": "eslint . --fix",
     "verify:bin": "pnpm build && [ -f dist/index.js ] || (echo 'dist/index.js not found' && exit 1)",
     "prepublishOnly": "pnpm build",
-    "prepare": "husky && husky install",
+    "prepare": "husky",
     "pre-commit": "pnpm lint && pnpm build:check && pnpm verify:bin",
     "semantic-release": "semantic-release",
     "check:include": "pnpm build && pnpm exec node dist/index.js src",


### PR DESCRIPTION
This PR fixes the husky hooks to allow semantic-release to push to the main branch during CI/CD workflows. It also updates the husky configuration to use the latest recommended format, fixing the deprecation warnings.