### PR TITLE
feat: skip tests for template markdown changes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,25 @@ permissions:
   pull-requests: write
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.filter.outputs.only_templates_md }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            only_templates_md:
+              - templates/**/*.md
+              - '!**/*.{js,ts,jsx,tsx,json,yml,yaml}'
+
   test:
+    needs: check_changes
+    if: ${{ needs.check_changes.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,25 @@ permissions:
   pull-requests: write
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      only_templates_md: ${{ steps.filter.outputs.only_templates_md }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            only_templates_md:
+              - templates/**/*.md
+              - '!**/*.{js,ts,jsx,tsx,json,yml,yaml}'
+
   release:
     name: Release
+    needs: check_changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +49,8 @@ jobs:
           version: 8
       - run: pnpm install
       - run: pnpm build
-      - run: pnpm test
+      - if: ${{ needs.check_changes.outputs.only_templates_md != 'true' }}
+        run: pnpm test
       - name: Verify CLI
         run: |
           pnpm link --global

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -10,6 +10,14 @@ if [ -z "$CI" ]; then
     exit 1
   fi
 
+  # Check if only markdown files in templates directory are changed
+  only_template_md_changed=$(git diff --cached --name-only | grep -v "^templates/.*\.md$" | wc -l)
+  
+  if [ "$only_template_md_changed" -eq "0" ] && [ "$(git diff --cached --name-only | wc -l)" -gt "0" ]; then
+    echo "✅ Only template markdown files changed. Skipping tests."
+    exit 0
+  fi
+
   # Install deps, lint, type check, test
   pnpm install && \
   pnpm eslint . --fix --max-warnings 0 && \


### PR DESCRIPTION
## Summary
Implement workflow optimizations to skip tests when only template markdown files are changed.

## Changes Made
- Updated pre-commit hook to detect and skip tests for template markdown changes
- Updated PR workflow to skip CI tests for template markdown changes using dorny/paths-filter
- Updated publish workflow to skip tests for template markdown changes

## Justification
- Improves developer workflow by allowing quick edits to template documentation
- Saves CI resources by avoiding unnecessary test runs
- Maintains all validations for non-template changes

## Testing
- Manually tested the pre-commit hook with sample template markdown changes
- Verified grep pattern correctly identifies template markdown files

## Additional Notes
- This change only affects markdown files in the templates directory
- All other code changes still require full test validation
