### PR TITLE
refactor: consolidate configuration management

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,23 @@
+import Conf from "conf";
+import { EditorConfig } from "./types.js";
+import { APP_NAME } from "./constants.js";
+
+// Default editor configuration
+export const DEFAULT_EDITOR_CONFIG: EditorConfig = {
+    command: "code",
+    skipEditor: false
+};
+
+// Single shared configuration instance
+export const config = new Conf<{ editor: EditorConfig }>({
+    projectName: APP_NAME,
+    projectSuffix: '', // Prevent -nodejs suffix in config path
+    defaults: {
+        editor: DEFAULT_EDITOR_CONFIG
+    }
+});
+
+// Helper function to get the editor configuration
+export function getConfig(): typeof config {
+    return config;
+} 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,24 +1,9 @@
 // src/editor.ts
 
-import Conf from "conf";
 import * as p from "@clack/prompts";
 import { EditorConfig } from "./types.js";
-import { APP_NAME } from "./constants.js"
 import { formatDebugMessage } from "./formatter.js";
-
-// Define the default editor configuration
-const DEFAULT_EDITOR_CONFIG: EditorConfig = {
-  command: "code",
-  skipEditor: false
-};
-
-// Global configuration for editor settings
-const config = new Conf<{ editor: EditorConfig }>({
-  projectName: APP_NAME,
-  defaults: {
-    editor: DEFAULT_EDITOR_CONFIG
-  }
-});
+import { config } from "./config.js";
 
 console.log(formatDebugMessage(`Editor config path: ${config.path}`));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,6 @@ import {
   PROP_TREE,
   PROP_CONTENT,
   DigestResult,
-  APP_NAME,
 } from "./constants.js";
 // Remove direct imports from templates as we're using dynamic imports now
 // import { listTemplates, loadAllTemplates } from "./templates.js";
@@ -40,7 +39,7 @@ import { getHashedSource } from "./utils.js";
 import { writeFile, mkdir } from "node:fs/promises";
 import { countTokens } from "./tokenCounter.js";
 import { execSync, spawn } from "node:child_process";
-import Conf from 'conf';
+import { config } from "./config.js";
 import { getEditorConfig } from "./editor.js";
 import path from "path";
 import os from "os";
@@ -236,12 +235,9 @@ export async function handleOutput(
         // Otherwise try to get the command from config
         console.log(formatDebugMessage(`No editor specified in command or empty string, attempting to read from config`));
         try {
-          // Create the config with defaults
+          // Get the editor config
           const editorConfig = await getEditorConfig();
-          console.log(formatDebugMessage(`Raw editor config from getEditorConfig(): ${JSON.stringify(editorConfig, null, 2)}`));
-
-          // Log the editor config for debugging
-          if (argv.debug) console.log(formatDebugMessage(`Editor config from getEditorConfig(): ${JSON.stringify(editorConfig, null, 2)}`));
+          console.log(formatDebugMessage(`Raw editor config for config flag: ${JSON.stringify(editorConfig, null, 2)}`));
 
           // Use the command from config if it's a string
           if (editorConfig && typeof editorConfig.command === 'string') {
@@ -431,21 +427,10 @@ export async function main(): Promise<number> {
     try {
       console.log(formatDebugMessage(`Processing --config flag`));
 
-      // Create a temporary Conf instance just to get the path
-      // Match the configuration in editor.ts with the same defaults
-      const tempConfig = new Conf({
-        projectName: APP_NAME,
-        defaults: {
-          editor: {
-            command: "code",
-            skipEditor: false
-          }
-        }
-      });
-
-      const configFilePath = tempConfig.path;
+      // Use the shared config instance
+      const configFilePath = config.path;
       console.log(formatDebugMessage(`Config file path: ${configFilePath}`));
-      console.log(formatDebugMessage(`Current config contents: ${JSON.stringify(tempConfig.store, null, 2)}`));
+      console.log(formatDebugMessage(`Current config contents: ${JSON.stringify(config.store, null, 2)}`));
 
       // Create the file with default editor config if it doesn't exist
       try {
@@ -458,9 +443,9 @@ export async function main(): Promise<number> {
         console.log(formatDebugMessage(`Created config directory: ${configDir}`));
 
         // Since we're using defaults, we don't need to explicitly create the file
-        // The file will be created automatically when we access tempConfig.store
+        // The file will be created automatically when we access config.store
         console.log(`Created new config file with default editor settings at: ${configFilePath}`);
-        console.log(formatDebugMessage(`Default config: ${JSON.stringify(tempConfig.store, null, 2)}`));
+        console.log(formatDebugMessage(`Default config: ${JSON.stringify(config.store, null, 2)}`));
       }
 
       console.log(`Opening configuration file: ${configFilePath}`);

--- a/test/pipe-flag.test.ts
+++ b/test/pipe-flag.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, afterAll } from "vitest";
 import { runCLI } from "./test-helpers.js";
 import { runDirectCLI } from "../utils/directTestRunner.js";
-import { writeFileSync } from "node:fs";
+import { writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 describe("CLI --pipe", () => {
@@ -12,7 +12,11 @@ describe("CLI --pipe", () => {
   // Write performance results to a file after tests complete
   afterAll(() => {
     if (performanceResults.length > 0) {
-      const resultsPath = join(process.cwd(), 'performance-results.txt');
+      // Create .temp directory if it doesn't exist
+      const perfDir = join(process.cwd(), '.temp');
+      mkdirSync(perfDir, { recursive: true });
+
+      const resultsPath = join(perfDir, 'pipe-flag-performance.txt');
       writeFileSync(resultsPath, performanceResults.join('\n'), 'utf8');
       console.log(`Performance results written to ${resultsPath}`);
     }


### PR DESCRIPTION
refactor: consolidate configuration management

## Changes
- Created new config.ts file for centralized configuration management
- Moved editor configuration from editor.ts to config.ts
- Updated index.ts to use shared configuration
- Added projectSuffix option to prevent -nodejs suffix in config path

## Problem
Configuration was scattered across multiple files with duplicate instances of Conf, leading to potential inconsistencies and incorrect path generation on WSL.

## Solution
- Consolidated all configuration into a single shared file
- Added projectSuffix option to fix WSL path issues
- Improved code organization and maintainability

## Testing
All tests are passing. The changes have been verified to work correctly on both standard environments and WSL.
