### PR TITLE
fix: Ensure --render-template respects --pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,28 @@ ffg /path/to/local/project
 ```
 
 ### Filter Files by Pattern
-```bash
-# Filter in current directory
-ffg --include "*.ts,*.tsx" --exclude "*.spec.*,node_modules"
 
-# Filter in specific directory
-ffg src --include "*.ts" --exclude "*.test.ts"
+Use glob patterns to precisely control which files are included or excluded.
+
+```bash
+# Include only TypeScript files in the root of the current directory
+ffg --include "*.ts"
+
+# Include TypeScript files recursively in all subdirectories
+ffg --include "**/*.ts"
+
+# Exclude node_modules and test files recursively
+ffg --exclude "**/*test.*,node_modules/**"
+
+# Combine include and exclude for specific filtering in the 'src' directory
+ffg src --include "**/*.ts" --exclude "**/*.spec.ts,**/__tests__/**"
 ```
+
+**Note:**
+- A pattern like `*.ts` matches files only in the immediate directory being scanned.
+- Use `**/*` to match files recursively through all subdirectories (e.g., `**/*.ts`).
+- You can provide multiple patterns separated by commas (e.g., `"*.ts,*.js"`) or by using multiple `--include` / `--exclude` flags (e.g., `--include "*.ts" --include "*.js"`).
+- You can also include specific files using their absolute paths alongside glob patterns (e.g., `ffg --include "**/*.ts,/Users/me/Documents/important_config.json"`).
 
 ### Search for Specific Content
 - **Find files containing ANY of the terms:**

--- a/src/index.ts
+++ b/src/index.ts
@@ -707,24 +707,35 @@ export async function main(): Promise<number> {
       const renderedContent = await processTemplate(template.templateContent);
       if (argv.debug) console.log(formatDebugMessage(`Template rendered successfully. Length: ${renderedContent.length}`));
 
-      // Create a temporary file
-      const tempFilePath = path.join(os.tmpdir(), `${TEMP_FILE_PREFIX}${templateName}-${Date.now()}${TEMP_FILE_SUFFIX}`);
-      await fs.writeFile(tempFilePath, renderedContent, 'utf8');
+      // === Add this conditional logic ===
+      if (argv.pipe) {
+        // Pipe mode: Write rendered content directly to stdout
+        process.stdout.write(renderedContent);
+        // Add a marker for testing purposes
+        if (process.env["VITEST"]) {
+          console.log(`\nTEST_RENDERED_TO_STDOUT`);
+        }
+      } else {
+        // Original mode: Save to temp file and open in editor
+        const tempFilePath = path.join(os.tmpdir(), `${TEMP_FILE_PREFIX}${templateName}-${Date.now()}${TEMP_FILE_SUFFIX}`);
+        await fs.writeFile(tempFilePath, renderedContent, 'utf8');
 
-      // Special logging for test environment
-      if (process.env["VITEST"]) {
-        console.log(`TEST_TEMP_FILE_PATH:${tempFilePath}`);
+        // Special logging for test environment
+        if (process.env["VITEST"]) {
+          console.log(`TEST_TEMP_FILE_PATH:${tempFilePath}`);
+        }
+
+        console.log(formatSaveMessage(`Rendered template saved to temporary file: ${tempFilePath}`, !process.env["VITEST"]));
+
+        // Special editor logging for test environment
+        if (process.env["VITEST"] && typeof argv.open === 'string') {
+          console.log(`TEST_EDITOR_COMMAND:${argv.open}`);
+        }
+
+        // Open the temporary file in the editor
+        await openFileInEditor(tempFilePath, argv.open, argv.debug);
       }
-
-      console.log(formatSaveMessage(`Rendered template saved to temporary file: ${tempFilePath}`, !process.env["VITEST"]));
-
-      // Special editor logging for test environment
-      if (process.env["VITEST"] && typeof argv.open === 'string') {
-        console.log(`TEST_EDITOR_COMMAND:${argv.open}`);
-      }
-
-      // Open the temporary file in the editor
-      await openFileInEditor(tempFilePath, argv.open, argv.debug);
+      // ==================================
 
       return 0; // Exit successfully
     } catch (error) {

--- a/templates/main/worktree.md
+++ b/templates/main/worktree.md
@@ -7,7 +7,7 @@ variables:
   - BRANCH_NAME # Still useful for push/PR commands, even if branch exists
 ---
 <executive_summary>
-Generate a step-by-step guide for working within an existing Git worktree. Assumes the worktree is linked to the correct feature branch. Includes implementation, testing (with commits per step), pushing the branch, and creating a Pull Request.
+Generate a step-by-step guide for implementing a task **assuming you are already working inside the relevant Git worktree and on the correct feature branch.** This guide covers code implementation, testing (with commits per step), pushing the branch, and creating a Pull Request.
 </executive_summary>
 
 <instructions>

--- a/test/exclude-flag.test.ts
+++ b/test/exclude-flag.test.ts
@@ -20,4 +20,25 @@ describe("CLI --exclude", () => {
     // But the .ts file is still present
     expect(stdout).toMatch(/test\.ts/);
   });
+
+  it("excludes patterns from multiple --exclude flags", async () => {
+    // We'll exclude *.md and *.js
+    const { stdout, exitCode } = await runCLI([
+      "--path",
+      "test/fixtures/sample-project",
+      "--exclude",
+      "*.md",
+      "--exclude",
+      "*.js",
+      "--pipe",
+    ]);
+
+    expect(exitCode).toBe(0);
+    // Output shouldn't have 'readme.md' or 'hello.js'
+    expect(stdout).not.toMatch(/readme\.md/);
+    expect(stdout).not.toMatch(/hello\.js/);
+
+    // But the .ts file is still present
+    expect(stdout).toMatch(/test\.ts/);
+  });
 });


### PR DESCRIPTION
Updated worktree.md template for clarity.

Modified src/index.ts to output to stdout when --render-template and --pipe are used.

Relinked globally to fix issue where wrong ffg version was executed.

Added missing dependencies identified by linter.