### PR TITLE
Fix: Prevent Escaping of XML Content

### DIFF
--- a/src/xmlFormatter.ts
+++ b/src/xmlFormatter.ts
@@ -140,7 +140,7 @@ export async function buildXMLOutput(
             const content = fileContent.replace(/^=+\nFile: .*\n=+\n/, "");
 
             xml += `${childIndent}<file path="${escapeXML(fullPath)}">\n`;
-            xml += `${escapeXML(content)}`;
+            xml += `${content}`;
             xml += `${childIndent}</file>\n`;
         }
 

--- a/test/duplicate-lines.test.ts
+++ b/test/duplicate-lines.test.ts
@@ -121,7 +121,7 @@ describe("duplicate lines", () => {
     expect(xmlResult.exitCode).toBe(0);
     expect(xmlResult.stdout).toContain("<files>");
     expect(xmlResult.stdout).toContain("<file");
-    expect(xmlResult.stdout).toContain("console.log(&apos;test1&apos;)");
-    expect(xmlResult.stdout).toContain("console.log(&apos;test2&apos;)");
+    expect(xmlResult.stdout).toContain("console.log('test1');");
+    expect(xmlResult.stdout).toContain("console.log('test2');");
   });
 });

--- a/test/include-file-check.test.ts
+++ b/test/include-file-check.test.ts
@@ -42,7 +42,7 @@ describe("Include flag for specific file and directory paths", () => {
 
     // The output should contain package.json and its content
     expect(stdout).toContain('<file path="package.json">');
-    expect(stdout).toContain('{ &quot;name&quot;: &quot;include-test&quot; }');
+    expect(stdout).toContain('{ "name": "include-test" }');
 
     // The output should not contain the content from index.js
     expect(stdout).not.toContain("index.js");

--- a/test/svg-flag.test.ts
+++ b/test/svg-flag.test.ts
@@ -78,7 +78,7 @@ describe("SVG file handling", () => {
         // Test 3: Include SVG content with --svg and --verbose flags
         expect(verboseResult.exitCode).toBe(0);
         expect(verboseResult.stdout).toContain("This is a text file");
-        expect(verboseResult.stdout).toContain("&lt;svg xmlns");
-        expect(verboseResult.stdout).toContain("&lt;circle cx=");
+        expect(verboseResult.stdout).toContain("<svg xmlns");
+        expect(verboseResult.stdout).toContain("<circle cx=");
     });
 }); 

--- a/test/verbose-flag.test.ts
+++ b/test/verbose-flag.test.ts
@@ -65,7 +65,7 @@ describe("CLI --verbose flag", () => {
     expect(verboseXmlResult.exitCode).toBe(0);
     expect(verboseXmlResult.stdout).toContain("<files>");
     expect(verboseXmlResult.stdout).toContain("<file path=");
-    expect(verboseXmlResult.stdout).toContain("console.log(&apos;hello&apos;)");
+    expect(verboseXmlResult.stdout).toContain("console.log('hello')");
 
     // Test 4: Markdown format with verbose
     expect(verboseMarkdownResult.exitCode).toBe(0);

--- a/test/xmlFormatter.test.ts
+++ b/test/xmlFormatter.test.ts
@@ -36,4 +36,34 @@ describe("XML Formatter", () => {
 
         expect(output).not.toContain("<command>");
     });
+
+    it("should not escape special characters within content tags", async () => {
+        const specialContent = `This <contains> & "special" 'chars'.`;
+        const digest = {
+            [PROP_SUMMARY]: `Summary with ${specialContent}`,
+            [PROP_TREE]: `Tree with ${specialContent}`,
+            [PROP_CONTENT]: `====================\nFile: src/test & file.ts\n====================\n${specialContent}\nAnother line.`
+        };
+        const source = "/test/path";
+        const timestamp = "20240101-000000";
+
+        const output = await buildXMLOutput(digest, source, timestamp, {
+            verbose: true, // Ensure content is included
+            whitespace: true // Make checking easier
+        });
+
+        // Check summary
+        expect(output).toContain(`  <summary>
+    Summary with ${specialContent}
+  </summary>`);
+        // Check tree
+        expect(output).toContain(`  <directoryTree>
+Tree with ${specialContent}
+  </directoryTree>`);
+        // Check file content (escaping only in attribute)
+        expect(output).toContain(`    <file path="src/test &amp; file.ts">\n${specialContent}\nAnother line.    </file>`);
+        // Specifically check that special chars are NOT escaped in content
+        expect(output).not.toContain("&lt;contains&gt;");
+        expect(output).not.toContain(`&amp; "special" &apos;chars&apos;`);
+    });
 }); 


### PR DESCRIPTION
This PR modifies the XML formatter to prevent escaping special characters (<, >, &, ", \') within the content of <summary>, <directoryTree>, and <file> tags. Escaping is maintained only for the 'path' attribute in <file> tags. This ensures that the exact content of files is preserved in the XML output, which is necessary for certain downstream processing. Includes a test case to verify this behavior.