### PR TITLE
fix: Remove problematic isMainModule check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1115,19 +1115,7 @@ ${contentStr}
   return 0; // Return success by default
 }
 
-// Helper function to check if we're the main module
-function isMainModule(): boolean {
-  const importPath = new URL(import.meta.url).pathname;
-  const execPath = process.argv[1];
-  if (!execPath) return false;
-  // Compare last 3 path segments (e.g., '@org/package/dist/index.js')
-  return importPath.endsWith(execPath.split('/').slice(-3).join('/'));
-}
-
-// Only run main if this is the main module
-if (isMainModule()) {
-  main().catch((error) => {
-    console.error(error);
-    process.exit(1);
-  });
-}
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
Removes the isMainModule check in src/index.ts which was causing issues on Windows platforms (GH-58) and is generally unnecessary for this CLI application.