### PR TITLE
fix: increase timeout for flaky cli-dot test

### DIFF
--- a/test/test-cli-dot.test.ts
+++ b/test/test-cli-dot.test.ts
@@ -117,7 +117,7 @@ describe("CLI: ingest current directory with '.'", () => {
 
       // Wait for both files sequentially as well
       const directFileExists = await waitForFile(directFullPath, 30000, 50); // Reduced timeout back to 30s
-      const processFileExists = await waitForFile(processFullPath, 15000, 50);
+      const processFileExists = await waitForFile(processFullPath, 30000, 50);
 
       expect(directFileExists).toBe(true);
       expect(processFileExists).toBe(true);


### PR DESCRIPTION
Increased waitForFile timeout from 15s to 30s in test/test-cli-dot.test.ts to mitigate flakiness. Resolves intermittent test failures due to timeout.