### PR TITLE
ci: Disable pre-push hook during semantic-release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,8 @@ jobs:
         run: |
           pnpm link --global
           ffg --help || exit 1
+      - name: Disable pre-push hook
+        run: chmod -x .husky/pre-push
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -64,3 +66,6 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           pnpm semantic-release
+      - name: Re-enable pre-push hook
+        if: always()
+        run: chmod +x .husky/pre-push


### PR DESCRIPTION
Updates the publish workflow to temporarily disable the pre-push hook during the semantic-release step. This prevents the hook from blocking the automated release push.